### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A [Model Context Protocol server](https://modelcontextprotocol.io/) for managing Amazon DynamoDB resources. This server provides tools for table management, capacity management, and data operations.
 
+<a href="https://glama.ai/mcp/servers/3voqtftc3c"><img width="380" height="200" src="https://glama.ai/mcp/servers/3voqtftc3c/badge" alt="DynamoDB Server MCP server" /></a>
+
 ## Author
 
 Iman Kamyabi (ikmyb@icloud.com)


### PR DESCRIPTION
This PR adds a badge for the [DynamoDB MCP Server](https://glama.ai/mcp/servers/3voqtftc3c) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/3voqtftc3c"><img width="380" height="200" src="https://glama.ai/mcp/servers/3voqtftc3c/badge" alt="DynamoDB Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.