### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DynamoDB MCP Server
+[![smithery badge](https://smithery.ai/badge/@imankamyabi/dynamodb-mcp-server)](https://smithery.ai/server/@imankamyabi/dynamodb-mcp-server)
 
 A [Model Context Protocol server](https://modelcontextprotocol.io/) for managing Amazon DynamoDB resources. This server provides tools for table management, capacity management, and data operations.
 
@@ -34,6 +35,15 @@ Iman Kamyabi (ikmyb@icloud.com)
 
 ## Setup
 
+### Installing via Smithery
+
+To install DynamoDB Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@imankamyabi/dynamodb-mcp-server):
+
+```bash
+npx -y @smithery/cli install @imankamyabi/dynamodb-mcp-server --client claude
+```
+
+### Manual installation
 1. Install dependencies:
 ```bash
 npm install

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,37 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - awsAccessKeyId
+      - awsSecretAccessKey
+      - awsRegion
+    properties:
+      awsAccessKeyId:
+        type: string
+        description: The AWS access key ID.
+      awsSecretAccessKey:
+        type: string
+        description: The AWS secret access key.
+      awsRegion:
+        type: string
+        description: The AWS region.
+      awsSessionToken:
+        type: string
+        description: The AWS session token (optional).
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({
+      command: 'node',
+      args: ['dist/index.js'],
+      env: {
+        AWS_ACCESS_KEY_ID: config.awsAccessKeyId,
+        AWS_SECRET_ACCESS_KEY: config.awsSecretAccessKey,
+        AWS_REGION: config.awsRegion,
+        AWS_SESSION_TOKEN: config.awsSessionToken || ''
+      }
+    })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai?utm_campaign=pr) to render configurations for the end-user. It also allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@imankamyabi/dynamodb-mcp-server?utm_campaign=pr&modal=claim), claiming it and clicking "Deploy".
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. Note that the installation only works after the server is deployed.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂